### PR TITLE
fix: fluid grid layout for project cards (HOW-188)

### DIFF
--- a/apps/frontend/src/components/ProjectCard.tsx
+++ b/apps/frontend/src/components/ProjectCard.tsx
@@ -12,7 +12,7 @@ export const ProjectCard = ({
   projectSkills,
   title,
 }: ProjectType) => (
-  <Card className="max-w-md md:max-w-lg">
+  <Card className="w-full max-w-md">
     <Image
       alt={title}
       height={projectImage.dimensions.height}

--- a/apps/frontend/src/components/Sections/Projects.tsx
+++ b/apps/frontend/src/components/Sections/Projects.tsx
@@ -6,7 +6,7 @@ import { ProjectCard } from "../ProjectCard";
 export const Projects = ({ headerText, projects }: ProjectSectionType) => (
   <div className="w-full space-y-5">
     <H2 className="text-center">{headerText}</H2>
-    <div className="flex flex-col items-center justify-evenly gap-5 md:flex-row">
+    <div className="grid grid-cols-[repeat(auto-fit,minmax(min(20rem,100%),1fr))] place-items-center gap-5">
       {projects.map((project) => (
         <ProjectCard key={project.title} {...project} />
       ))}


### PR DESCRIPTION
## Summary
- Projects section switched from a single `flex-col`/`md:flex-row` breakpoint jump to a fluid `grid-cols-[repeat(auto-fit,minmax(min(20rem,100%),1fr))]` layout, so column count adapts continuously to container width instead of snapping at one breakpoint
- ProjectCard width changed from a fixed `max-w-md`/`md:max-w-lg` jump to `w-full max-w-md`, letting it shrink/grow fluidly within its grid cell

## Why
Cards previously overflowed/squished at widths between the flex-row switch and where 2-3 cards actually fit, since flex items weren't wrapping.

Closes HOW-188.

## Test plan
- [x] `pnpm dlx ultracite fix` — no issues
- [x] `pnpm run typecheck` (apps/frontend) — passes
- [ ] Manually verify in browser across widths (not run — no dev server started in this session)
