### PR TITLE
ci: add production promotion PR and deploy workflows

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,37 @@
+name: Deploy Production
+
+on:
+  push:
+    branches:
+      - production
+
+jobs:
+  deploy:
+    strategy:
+      matrix:
+        include:
+          - app: frontend
+            project_id_var: VERCEL_PROJECT_ID_FRONTEND
+          - app: admin
+            project_id_var: VERCEL_PROJECT_ID_ADMIN
+          - app: cms
+            project_id_var: VERCEL_PROJECT_ID_CMS
+    name: Deploy ${{ matrix.app }} to Vercel (Production)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Deploy to Vercel (Production)
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars[matrix.project_id_var] }}
+        run: |
+          npx vercel@latest pull --yes --environment=production --token="$VERCEL_TOKEN"
+          npx vercel@latest build --prod --token="$VERCEL_TOKEN"
+          npx vercel@latest deploy --prebuilt --prod --token="$VERCEL_TOKEN"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,27 @@
+name: Release PR
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open or update promotion PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" --base production --head main --state open --json number --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            gh pr create --repo "$GITHUB_REPOSITORY" \
+              --base production \
+              --head main \
+              --title "chore: promote main to production" \
+              --body "Auto-generated promotion PR. Merging this deploys \`main\` to production."
+          fi


### PR DESCRIPTION
Adds the staging/production branch workflow pieces:

- `release-pr.yml` — on every push to `main`, opens/updates a promotion PR from `main` -> `production`
- `deploy-production.yml` — on push to `production`, deploys frontend/admin/cms to Vercel production via the Vercel CLI

Created the `production` branch from current `main`.

See PR description / chat for required repo secrets and variables.
