### PR TITLE
ci: use github app token for release PR creation

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -13,9 +13,16 @@ jobs:
   release-pr:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate a token
+        id: id-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Open or update promotion PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.id-token.outputs.token }}
         run: |
           PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" --base production --head main --state open --json number --jq '.[0].number // empty')
           if [ -z "$PR_NUMBER" ]; then


### PR DESCRIPTION
Follow-up to #1716, which merged before this fix landed.

`release-pr.yml` was using the default `GITHUB_TOKEN` to open the `main` -> `production` promotion PR. PRs (and pushes) authored with the default token don't trigger other workflows, so any workflow on `production` gated behind "requires approval to run" would sit stuck. Switches to the repo's existing GitHub App token (`APP_ID` / `APP_PRIVATE_KEY`), same pattern already used in `dependabot-auto-merge.yml`.
