### PR TITLE
ci: generate release PR body from pending commits

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -20,6 +20,26 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.id-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Fetch production branch
+        env:
+          GH_TOKEN: ${{ steps.id-token.outputs.token }}
+        run: git fetch "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" production:refs/remotes/origin/production
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Build release PR body
+        run: node scripts/build-release-pr-body.mjs > release-pr-body.md
+
       - name: Open or update promotion PR
         env:
           GH_TOKEN: ${{ steps.id-token.outputs.token }}
@@ -30,5 +50,7 @@ jobs:
               --base production \
               --head main \
               --title "chore: promote main to production" \
-              --body "Auto-generated promotion PR. Merging this deploys \`main\` to production."
+              --body-file release-pr-body.md
+          else
+            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body-file release-pr-body.md
           fi

--- a/scripts/build-release-pr-body.mjs
+++ b/scripts/build-release-pr-body.mjs
@@ -1,0 +1,50 @@
+import { execFileSync } from "node:child_process";
+
+const { GITHUB_REPOSITORY } = process.env;
+
+if (!GITHUB_REPOSITORY) {
+  throw new Error(
+    "GITHUB_REPOSITORY is not set — this script must run in GitHub Actions."
+  );
+}
+
+const [owner, repo] = GITHUB_REPOSITORY.split("/");
+const log = execFileSync("git", [
+  "log",
+  "--pretty=format:%H%x01%s%x01%an",
+  "origin/production..origin/main",
+]).toString();
+
+const commits = log
+  .split("\n")
+  .filter(Boolean)
+  .map((line) => {
+    const [sha, subject, author] = line.split("\x01");
+    return { author, sha, subject };
+  });
+
+const prLinkPattern = /\(#(\d+)\)\s*$/;
+
+const lines = commits.map(({ sha, subject, author }) => {
+  const match = subject.match(prLinkPattern);
+  if (match) {
+    const [, prNumber] = match;
+    const title = subject.replace(prLinkPattern, "").trim();
+    return `- ${title} ([#${prNumber}](https://github.com/${owner}/${repo}/pull/${prNumber})) — ${author}`;
+  }
+  const shortSha = sha.slice(0, 7);
+  return `- ${subject} ([\`${shortSha}\`](https://github.com/${owner}/${repo}/commit/${sha})) — ${author}`;
+});
+
+const compareUrl = `https://github.com/${owner}/${repo}/compare/production...main`;
+const commitCount = commits.length;
+const commitNoun = commitCount === 1 ? "commit" : "commits";
+
+const body = `Auto-generated release PR.
+
+**${commitCount} ${commitNoun}** pending release ([full diff](${compareUrl})):
+
+${lines.length > 0 ? lines.join("\n") : "_No commits yet._"}
+`;
+
+process.stdout.write(body);


### PR DESCRIPTION
The `main -> production` promotion PR was using a static body. This ports shs-football-ads' `build-release-pr-body.mjs` script so the body instead lists every commit pending release (linking the PR number when the commit subject has one) plus a compare link, and updates the PR body on every subsequent push to `main` rather than only when the PR is created.
