### PR TITLE
docs: note --no-dry-run flag for portable text migration

### DIFF
--- a/apps/cms/migrations/convert-about-content-to-portable-text.ts
+++ b/apps/cms/migrations/convert-about-content-to-portable-text.ts
@@ -5,7 +5,7 @@ import { at, defineMigration, set } from "sanity/migrate";
  * aboutSection.content used to be a plain string; it's now a Portable Text
  * block array. Wraps any remaining string values in a single normal block.
  *
- * Run with: sanity migration run convert-about-content-to-portable-text --dataset <dataset> --no-dry-run
+ * Run with: sanity migration run convert-about-content-to-portable-text --project b6x3by70 --dataset <dataset> --no-dry-run
  * (omitting --no-dry-run only prints the mutations, it does not apply them)
  */
 export default defineMigration({

--- a/apps/cms/migrations/convert-about-content-to-portable-text.ts
+++ b/apps/cms/migrations/convert-about-content-to-portable-text.ts
@@ -5,7 +5,8 @@ import { at, defineMigration, set } from "sanity/migrate";
  * aboutSection.content used to be a plain string; it's now a Portable Text
  * block array. Wraps any remaining string values in a single normal block.
  *
- * Run with: sanity migration run convert-about-content-to-portable-text --dataset <dataset>
+ * Run with: sanity migration run convert-about-content-to-portable-text --dataset <dataset> --no-dry-run
+ * (omitting --no-dry-run only prints the mutations, it does not apply them)
  */
 export default defineMigration({
   documentTypes: ["home"],


### PR DESCRIPTION
## Summary
- The HOW-191 migration appeared to do nothing on staging/production after being run.
- Root cause: `sanity migration run` is a dry run by default and requires `--no-dry-run` to actually apply mutations.
- Updates the migration file's doc comment with the correct command.

## Test plan
- [x] `pnpm --filter @kduprey/cms exec tsc --noEmit` passes
