### PR TITLE
feat: migration to remove orphaned skills fields (HOW-189)

### DIFF
--- a/apps/cms/migrations/remove-orphaned-skills-fields.ts
+++ b/apps/cms/migrations/remove-orphaned-skills-fields.ts
@@ -1,0 +1,24 @@
+import { at, defineMigration, unset } from "sanity/migrate";
+
+/**
+ * HOW-189 removed the skills feature from the schema (home.skillsSection,
+ * project.projectSkills) but left the data on existing documents, which Studio
+ * now flags as "field not defined in schema". Unsets both fields.
+ *
+ * Run with: sanity migration run remove-orphaned-skills-fields --dataset <dataset> --no-dry-run
+ * (omitting --no-dry-run only prints the mutations, it does not apply them)
+ */
+export default defineMigration({
+  documentTypes: ["home", "project"],
+  migrate: {
+    document(doc: Record<string, unknown>) {
+      if (doc._type === "home" && "skillsSection" in doc) {
+        return at("skillsSection", unset());
+      }
+      if (doc._type === "project" && "projectSkills" in doc) {
+        return at("projectSkills", unset());
+      }
+    },
+  },
+  title: "Remove orphaned skills fields from home and project documents",
+});

--- a/apps/cms/migrations/remove-orphaned-skills-fields.ts
+++ b/apps/cms/migrations/remove-orphaned-skills-fields.ts
@@ -5,7 +5,7 @@ import { at, defineMigration, unset } from "sanity/migrate";
  * project.projectSkills) but left the data on existing documents, which Studio
  * now flags as "field not defined in schema". Unsets both fields.
  *
- * Run with: sanity migration run remove-orphaned-skills-fields --dataset <dataset> --no-dry-run
+ * Run with: sanity migration run remove-orphaned-skills-fields --project b6x3by70 --dataset <dataset> --no-dry-run
  * (omitting --no-dry-run only prints the mutations, it does not apply them)
  */
 export default defineMigration({


### PR DESCRIPTION
## Summary
- HOW-189 removed `home.skillsSection` and `project.projectSkills` from the schema without a migration, so existing documents still carry that data and Studio now flags it as "field not defined in schema".
- Adds a migration that unsets both fields on `home`/`project` documents.

## Follow-up not included here
- Existing `skill` documents (the whole document type was deleted) are now orphaned and will also show as an undefined type in Studio. Deleting documents is destructive, so that's intentionally left out of this migration — flagging for a decision on whether to delete them or leave them as historical data.

## Test plan
- [x] `pnpm --filter @kduprey/cms exec tsc --noEmit` passes
- [ ] Run `sanity migration run remove-orphaned-skills-fields --dataset staging --no-dry-run` and confirm the schema warning clears in Studio
- [ ] Repeat for production
