### PR TITLE
ci: create a Sentry release for admin too, not just site

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,13 +56,25 @@ jobs:
         run: |
           gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --notes-file "$NOTES_FILE" --target "$GITHUB_SHA"
 
-      - name: Create Sentry release
+      - name: Create Sentry release (site)
         if: steps.release.outputs.released == 'true'
         uses: getsentry/action-release@v3
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_URL: ${{ vars.SENTRY_URL }}
+        with:
+          environment: production
+          version: ${{ steps.release.outputs.tag }}
+
+      - name: Create Sentry release (admin)
+        if: steps.release.outputs.released == 'true'
+        uses: getsentry/action-release@v3
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: kentonduprey-admin
           SENTRY_URL: ${{ vars.SENTRY_URL }}
         with:
           environment: production

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,8 @@ jobs:
         uses: getsentry/action-release@v3
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT_SITE }}
           SENTRY_URL: ${{ vars.SENTRY_URL }}
         with:
           environment: production
@@ -100,8 +100,8 @@ jobs:
         uses: getsentry/action-release@v3
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: kentonduprey-admin
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT_ADMIN }}
           SENTRY_URL: ${{ vars.SENTRY_URL }}
         with:
           environment: production

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      released: ${{ steps.release.outputs.released }}
+      tag: ${{ steps.release.outputs.tag }}
     steps:
       - name: Generate a token
         id: id-token
@@ -56,8 +59,20 @@ jobs:
         run: |
           gh release create "$RELEASE_TAG" --title "$RELEASE_TAG" --notes-file "$NOTES_FILE" --target "$GITHUB_SHA"
 
-      - name: Create Sentry release (site)
-        if: steps.release.outputs.released == 'true'
+  sentry-release-site:
+    name: Create Sentry release (site)
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Create Sentry release
         uses: getsentry/action-release@v3
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -66,10 +81,22 @@ jobs:
           SENTRY_URL: ${{ vars.SENTRY_URL }}
         with:
           environment: production
-          version: ${{ steps.release.outputs.tag }}
+          version: ${{ needs.release.outputs.tag }}
 
-      - name: Create Sentry release (admin)
-        if: steps.release.outputs.released == 'true'
+  sentry-release-admin:
+    name: Create Sentry release (admin)
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Create Sentry release
         uses: getsentry/action-release@v3
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -78,4 +105,4 @@ jobs:
           SENTRY_URL: ${{ vars.SENTRY_URL }}
         with:
           environment: production
-          version: ${{ steps.release.outputs.tag }}
+          version: ${{ needs.release.outputs.tag }}


### PR DESCRIPTION
release.yml only ever created a Sentry release against the site's SENTRY_PROJECT secret. Admin has its own Sentry project ("kentonduprey-admin", set in apps/admin/next.config.mjs's withSentryConfig) that was never getting a release tagged for it. Adds a second getsentry/action-release step for it.