### PR TITLE
fix: install pnpm before running vercel build in deploy-production

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -26,6 +26,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Deploy to Vercel (Production)
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
Both times deploy-production.yml has run (production pushes on 2026-07-28 and 2026-07-29), all three deploy jobs (admin, cms, frontend) failed identically:

```
Detected `pnpm-lock.yaml` 9 which may be generated by pnpm@9.x or pnpm@10.x.
Using pnpm@9.x based on project creation date.
Installing dependencies...
Error: spawn pnpm ENOENT
```

`vercel build` shells out to a local `pnpm` binary, but the workflow never installed one before running it. Adds the same `pnpm/action-setup` step already used in release.yml and release-pr.yml, which picks up the version pinned in package.json's `packageManager` field (pnpm@10.24.0).
