### PR TITLE
fix: generate Prisma client on install, not just packages/db's own build

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "migration:live": "pnpm --filter @kduprey/cms migration:live",
     "migration:prod": "pnpm --filter @kduprey/cms migration:prod",
     "migration:live:prod": "pnpm --filter @kduprey/cms migration:live:prod",
-    "publishContent": "pnpm --filter @kduprey/cms publishContent",
     "postinstall": "pnpm --filter @kduprey/db generate",
+    "publishContent": "pnpm --filter @kduprey/cms publishContent",
     "pullContent": "pnpm --filter @kduprey/cms pullContent",
     "start": "pnpm dlx turbo start",
     "start:db:local": "docker-compose up -d && dotenv -- pnpm --filter @kduprey/db migrate",
@@ -36,6 +36,9 @@
   "keywords": [],
   "author": "Kenton Duprey",
   "packageManager": "pnpm@10.24.0",
+  "prisma": {
+    "schema": "packages/db/prisma/schema.prisma"
+  },
   "pnpm": {
     "onlyBuiltDependencies": [
       "@clerk/shared",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "migration:prod": "pnpm --filter @kduprey/cms migration:prod",
     "migration:live:prod": "pnpm --filter @kduprey/cms migration:live:prod",
     "publishContent": "pnpm --filter @kduprey/cms publishContent",
+    "postinstall": "pnpm --filter @kduprey/db generate",
     "pullContent": "pnpm --filter @kduprey/cms pullContent",
     "start": "pnpm dlx turbo start",
     "start:db:local": "docker-compose up -d && dotenv -- pnpm --filter @kduprey/db migrate",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -31,5 +31,8 @@
     "prisma": "^7.9.0",
     "tsup": "^8.4.0",
     "typescript": "^5.9.3"
+  },
+  "prisma": {
+    "schema": "./prisma/schema.prisma"
   }
 }


### PR DESCRIPTION
Vercel deploys each app by running its own `pnpm run build` (== `next build`) directly, never through Turborepo's dependency graph — so packages/db's own `build` script (which runs `prisma generate`) never executed. Production build failed on:

```
Module not found: Can't resolve './generated/prisma/client'
```

(confirmed via the actual production deploy run: https://github.com/kduprey/kentonduprey-site/actions/runs/30418407596)

Adds a root-level `postinstall` hook so the client is generated right after `pnpm install`, regardless of which app's build command runs next.

Verified locally: deleted `packages/db/src/generated`, ran `pnpm install`, confirmed it regenerates automatically. `apps/frontend` typecheck and `next build` (which previously failed at the Prisma import) both get past that stage cleanly now.

**Needs verification I can't do from here:** `prisma generate` requires `DATABASE_URL` to be *set* (any syntactically valid value — it doesn't connect), because `prisma.config.ts` validates it eagerly. Please confirm `DATABASE_URL` is configured in the frontend and admin Vercel projects' build environment.
