### PR TITLE
ci: run each app's Vercel build through turbo, not the bare next build

### DIFF
--- a/apps/admin/vercel.json
+++ b/apps/admin/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "turbo run build"
+}

--- a/apps/cms/vercel.json
+++ b/apps/cms/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "turbo run build"
+}

--- a/apps/frontend/vercel.json
+++ b/apps/frontend/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "turbo run build"
+}


### PR DESCRIPTION
Root Directory is set to each app's own subfolder (`apps/frontend`, `apps/admin`, `apps/cms`) for all three Vercel projects, so Vercel's default build command just runs that app's own bare `next build` — completely bypassing Turborepo's dependency graph. That's what's been causing production builds to fail: `packages/db`'s `build` task (which runs `prisma generate`) never gets a chance to run.

Per [Vercel's own docs](https://vercel.com/docs/monorepos/turborepo), when Root Directory points at an app subfolder in a Turborepo monorepo, the documented build command is `turbo run build` — Turborepo's automatic workspace scoping infers the right `--filter` from cwd, no explicit filter needed.

**Verified locally:** running `pnpm exec turbo run build` from inside `apps/frontend` correctly scopes to `Packages in scope: @kduprey/frontend` and runs `packages/db`'s build (`prisma generate`) as a dependency first, before frontend's own build runs.

Adds `vercel.json` to each app declaring `"buildCommand": "turbo run build"`, since our deploys go through a custom GitHub Actions workflow (`deploy-production.yml`) that runs `vercel build` via the CLI rather than Vercel's own git integration — `vercel.json` is documented as an equally valid way to set this, applying identically either way.

**Flagging, not fixing here:** `packages/db`'s `build` script also runs `prisma migrate deploy`, which will now actually execute during every frontend and admin build (previously dormant since turbo never ran). Both apps depend on `packages/db`, and `deploy-production.yml` builds all three apps concurrently — meaning two concurrent `prisma migrate deploy` attempts against production on every deploy. Worth a follow-up to split `packages/db`'s build script so migration only happens once.
