### PR TITLE
fix: run migrations once, decoupled from per-app builds

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -6,7 +6,44 @@ on:
       - production
 
 jobs:
+  migrate:
+    name: Apply database migrations
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Apply pending migrations
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_ADMIN }}
+        run: |
+          npx vercel@latest pull --yes --environment=production --token="$VERCEL_TOKEN"
+          set -a
+          . ./.vercel/.env.production.local
+          set +a
+          pnpm --filter @kduprey/db migrate:deploy
+
   deploy:
+    needs: migrate
     strategy:
       matrix:
         include:

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -7,7 +7,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "build": "prisma migrate deploy && pnpm generate",
+    "build": "pnpm generate",
     "predev": "pnpm generate",
     "dev": "tsup src/* --watch",
     "format": "prisma format",
@@ -15,6 +15,7 @@
     "lint": "ultracite check .",
     "lint:fix": "ultracite fix .",
     "migrate": "prisma migrate dev",
+    "migrate:deploy": "prisma migrate deploy",
     "push": "prisma db push --skip-generate",
     "seed": "prisma db seed",
     "studio": "prisma studio"

--- a/packages/db/prisma.config.ts
+++ b/packages/db/prisma.config.ts
@@ -1,5 +1,7 @@
-import "dotenv/config";
+import { config } from "dotenv";
 import { defineConfig, env } from "prisma/config";
+
+config({ path: [".env.local", ".env"] });
 
 interface Env {
   DATABASE_URL: string;


### PR DESCRIPTION
`packages/db`'s `build` script did `prisma migrate deploy && pnpm generate` — both admin and frontend depend on `packages/db`, and with turbo now actually wired into the Vercel build (#1748), that combined script would run as part of each app's own build. `deploy-production.yml` builds all three apps concurrently, so this meant two simultaneous `prisma migrate deploy` attempts against the production database on every deploy — I couldn't find documentation confirming that's actually safe, so treating it as a real risk rather than assuming Prisma handles it.

**Fix:** split it.
- `packages/db`'s `build` script is now generate-only (fast, idempotent, no live DB connection needed — verified locally).
- Migration deploy gets its own script (`migrate:deploy`) and its own standalone job in `deploy-production.yml` that runs once, before the deploy matrix (`deploy` now `needs: migrate`), reusing the same `vercel pull` mechanism the deploy job already uses to fetch `DATABASE_URL` and other env vars — no new secret needed.

**Verified:** `turbo run build` from `apps/frontend` now succeeds through `packages/db`, `packages/config`, and `packages/ui` without any database connection at all; frontend's own build progresses to the same expected stopping point (a real Sanity secret it doesn't have locally) as before this change.

Stacks on #1748 (turbo wiring) — this is the follow-up it called out.
