### PR TITLE
fix: pull Vercel env before install in Deploy Production migrate job

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -27,20 +27,24 @@ jobs:
         with:
           node-version: 22.x
 
-      - name: Install dependencies
-        env:
-          # Placeholder so prisma.config.ts can resolve DATABASE_URL during the
-          # postinstall `prisma generate` — no live DB connection needed for generate.
-          DATABASE_URL: "postgresql://placeholder:placeholder@localhost:5432/placeholder"
-        run: pnpm install
-
-      - name: Apply pending migrations
+      - name: Pull Vercel environment
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID_ADMIN }}
+        run: npx vercel@latest pull --yes --environment=production --token="$VERCEL_TOKEN"
+
+      - name: Install dependencies
+        # DATABASE_URL must be set before install: packages/db's postinstall
+        # runs `prisma generate`, which resolves it eagerly via prisma.config.ts.
         run: |
-          npx vercel@latest pull --yes --environment=production --token="$VERCEL_TOKEN"
+          set -a
+          . ./.vercel/.env.production.local
+          set +a
+          pnpm install
+
+      - name: Apply pending migrations
+        run: |
           set -a
           . ./.vercel/.env.production.local
           set +a

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -28,6 +28,10 @@ jobs:
           node-version: 22.x
 
       - name: Install dependencies
+        env:
+          # Placeholder so prisma.config.ts can resolve DATABASE_URL during the
+          # postinstall `prisma generate` — no live DB connection needed for generate.
+          DATABASE_URL: "postgresql://placeholder:placeholder@localhost:5432/placeholder"
         run: pnpm install
 
       - name: Apply pending migrations


### PR DESCRIPTION
Deploy Production has been failing on every push to `production` since #1749: the `migrate` job's `pnpm install` runs before `vercel pull`, but `packages/db`'s postinstall (`prisma generate`) eagerly resolves `DATABASE_URL` via `prisma.config.ts` and fails when it isn't set yet.

Fixed by reordering the job to pull the Vercel env first, same as `shs-football-ads` (which has no bare-install-before-env-pull step anywhere in its CI).

Test steps:
- Re-run the `migrate` job on this branch (or push to `production`) — "Install dependencies" should succeed and the job should proceed to "Apply pending migrations".
