### PR TITLE
fix: remove root postinstall that required DATABASE_URL on every install

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "migration:live": "pnpm --filter @kduprey/cms migration:live",
     "migration:prod": "pnpm --filter @kduprey/cms migration:prod",
     "migration:live:prod": "pnpm --filter @kduprey/cms migration:live:prod",
-    "postinstall": "pnpm --filter @kduprey/db generate",
     "publishContent": "pnpm --filter @kduprey/cms publishContent",
     "pullContent": "pnpm --filter @kduprey/cms pullContent",
     "start": "pnpm dlx turbo start",


### PR DESCRIPTION
Follow-up to #1757/HOW-197. That PR reordered Deploy Production's `migrate` job to pull the Vercel env before install, but the same failure recurred on the **Release** workflow (https://github.com/kduprey/kentonduprey-site/actions/runs/30565914791/job/90950250003), which has no Vercel env and doesn't even need `packages/db` built.

Root cause: the root `postinstall` script ran `prisma generate` unconditionally on every `pnpm install`, and `prisma.config.ts` eagerly resolves `DATABASE_URL` at generate time. Any bare CI install without that env fails.

shs-football-ads has no such postinstall — it only generates the Prisma client through `turbo build`'s task graph. Removing it here is safe: local dev already generates the client via `prisma migrate dev`'s auto-generate during `start:db:local`, and Vercel builds cover it via `packages/db`'s own `build` script.

Test steps:
- Re-run the Release workflow on this branch — "Install dependencies" should succeed with no DATABASE_URL error.
- Re-run Deploy Production's migrate job — should still succeed (unaffected by this change).