### PR TITLE
fix: use full git history for Sentry release checkouts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Create Sentry release
@@ -94,6 +95,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Create Sentry release


### PR DESCRIPTION
https://github.com/kduprey/kentonduprey-site/actions/runs/30567055190/job/90954371372

Both `Create Sentry release (site)` and `Create Sentry release (admin)` jobs failed with:

```
error: Could not find the SHA of the previous release in the git history. If you limit the clone depth, try to increase it.
```

`sentry-cli releases set-commits --auto` needs full git history to find the previous release's commit. Both jobs used the default shallow checkout (fetch-depth: 1); the `release` job earlier in the same workflow already uses `fetch-depth: 0` for the same reason, but these two never got it.

Test steps:
- Re-run the Release workflow on `production` — both Sentry release jobs should succeed instead of failing on `set-commits`.